### PR TITLE
Fixes and updates for containerization

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,15 @@ installed.  There is an example Systemd unit file in the `systemd` folder.
 {
     "Server": "http://127.0.0.1:8080",
     "Key": "",
-    "RemoteDirectory": "/path/to/steam/remote/folder/"
+    "RemoteDirectory": "/path/to/steam/remote/folder/",
+    "Interval": 60
 }
 ```
 
 The remote directory can be found by clicking on the "Show on disk" button in
 the Steam Screenshot Manager window.  The path entered into the configuration
 should be an absolute path ending in `remote/`.
+The `Interval` value is the number of seconds between scans, setting it to zero will cause the uploader to exit after a single pass.
 
 ## Notes
 

--- a/handlers.go
+++ b/handlers.go
@@ -156,7 +156,7 @@ func (s *Server) handler_image(w http.ResponseWriter, r *http.Request) {
 		if _, exists := s.ImageCache.Games[appid]; exists {
 			bannerpath, err := s.getGameBanner(appid)
 			if err != nil {
-				http.ServeFileFs(w, r, s.StaticFiles, "banners/unknown.jpg")
+				http.ServeFileFS(w, r, s.StaticFiles, "banners/unknown.jpg")
 				return
 			}
 			http.ServeFile(w, r, bannerpath)

--- a/server.go
+++ b/server.go
@@ -230,10 +230,6 @@ func (s *Server) loadSettings(filename string) error {
 
 	fmt.Println("Settings loaded")
 
-	if s.settings.RefreshInterval < 1 {
-		s.settings.RefreshInterval = 1
-	}
-
 	// TODO: make this filename configurable
 	s.Games, err = LoadGameList("games.cache")
 	return err

--- a/server.go
+++ b/server.go
@@ -159,7 +159,7 @@ func (s *Server) Run() error {
 		}
 		s.settings.ApiKey = out
 		fmt.Println("New API key generated: " + s.settings.ApiKey)
-		if err = s.saveSettings("settings.json"); err != nil {
+		if err = s.saveSettings(s.SettingsFile); err != nil {
 			panic(fmt.Sprintf("unable to save settings: %v", err))
 		}
 	} else {

--- a/upload-config.json.example
+++ b/upload-config.json.example
@@ -1,0 +1,6 @@
+{
+    "Server": "http://server:8080",
+    "Key": "your-secure-api-key-here",
+    "RemoteDirectory": "/screenshots/",
+    "Interval": 10
+}


### PR DESCRIPTION
Some fixes and updates to allow for containerization

- Add config file argument for uploader (now the same as the server)
- Add refresh interval for uploader and related config item
- Add ability to use hostnames in API whitelist to allow for docker services to communicate
- Fix: Removed orphaned references to RefreshInterval in the server
- Fix: Take into account the config file argument when saving an API key to config file
- Fix: Typo on ServeFileFS 